### PR TITLE
Fix package name property to use legal characters

### DIFF
--- a/Chat/ClientApp/package.json
+++ b/Chat/ClientApp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ACS-Chat-Sample",
+  "name": "acs-chat-sample",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
- capital letters are not allowed for a name property
- use lowercase characters

## Purpose
Nodejs ClientApp's package.json was using illegal charcters for the name property.  converted name to lowecase letters

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
Refer to package.json docs for explanation of valid characters:  https://docs.npmjs.com/cli/v6/configuring-npm/package-json#name
