### PR TITLE
Add ARM template for deploying with an existing resource

### DIFF
--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appName": {
+      "type": "string"
+    },
+    "sku": {
+      "type": "string",
+      "defaultValue": "F1",
+      "metadata": {
+        "description": "The SKU of App Service Plan."
+      }
+    }
+  },
+  "variables": {
+    "communicationServicesResourceId": "<Enter your Azure Communication Services Resource Id>",
+    "location": "[resourceGroup().location]",
+    "appServicePlanPortalName": "[concat('AppServicePlan-', parameters('appName'))]",
+    "packageUrl": "https://github.com/Azure-Samples/communication-services-web-chat-hero/releases/latest/download/group-chat.zip"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('appServicePlanPortalName')]",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "[parameters('sku')]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('appName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+      ],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+      },
+      "resources": [
+        {
+          "name": "appsettings",
+          "type": "config",
+          "apiVersion": "2018-11-01",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', parameters('appName'))]"
+          ],
+          "tags": {
+            "displayName": "appsettings"
+          },
+          "properties": {
+            "ResourceConnectionString": "[listkeys(variables('communicationServicesResourceId'), '2020-08-20' ).primaryConnectionString]",
+            "EndpointUrl": "[substring(listkeys(variables('communicationServicesResourceId'), '2020-08-20' ).primaryConnectionString, 9, add(indexOf(listkeys(variables('communicationServicesResourceId'), '2020-08-20' ).primaryConnectionString, '.azure.com/'),2))]",
+            "WEBSITE_NODE_DEFAULT_VERSION": "~14"
+          }
+        },
+        {
+          "name": "MSDeploy",
+          "type": "extensions",
+          "location": "[resourceGroup().location]",
+          "apiVersion": "2015-08-01",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', parameters('appName'))]",
+            "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'appsettings')]"
+          ],
+          "properties": {
+            "packageUri": "[variables('packageUrl')]"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose

* To add a new ARM template where an existing Azure Communication Services resource is used instead of deploying a new one
* One use of this template will be from the 'Sample applications' blade in the Azure Portal, where users can deploy the chat hero sample using the existing resource. Mock up:

![2022-05-24 13_46_55-sample-apps-chat](https://user-images.githubusercontent.com/43504546/170129342-580bbf6f-2148-4144-8524-c9fd76fe581d.png)



## Pull Request Type

<!-- What kind of change does this Pull Request introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: new ARM template
```

## Upstream sample reference

<!-- In most cases, a change here synchronizes this sample with the upstream sample. -->

Links to PR(s) that made the original change in the [upstream sample](https://github.com/Azure/communication-ui-library/tree/main/samples/Calling):

* ...

## How to Test

*  Get the code

```
git clone [repo-address]
cd [repo-name]
```

* Set Azure Communication Services Resource Id
1. Retrieve the resource id for your Communication Services resource
1. Open `deploy/azuredeployexistingresource.json`
1. Set `communicationServicesResourceId`

* Test the code

<!-- Add steps to run the tests suite and/or manually test. -->
1. Deploy the ARM template via CLI or custom deployment in Azure Portal (portal.azure.com/#create/Microsoft.Template)

## What to Check

Verify that the following are valid

* Can send chat messages:

![2022-05-24 13_29_13-](https://user-images.githubusercontent.com/43504546/170131824-2e97a72c-30a2-4557-b2af-0a4cd985925e.png)


## Other Information

<!-- Add any other helpful information that may be needed here. -->
