### PR TITLE
Add ability to add existing threads and thread participants

### DIFF
--- a/Chat/common.webpack.config.js
+++ b/Chat/common.webpack.config.js
@@ -71,6 +71,10 @@ const webpackConfig = (sampleAppDir, env, babelConfig) => {
           target: 'http://[::1]:8080'
         },
         {
+          path: '/addThread',
+          target: 'http://[::1]:8080'
+        },
+        {
           path: '/userConfig/*',
           target: 'http://[::1]:8080'
         },

--- a/Chat/src/app/utils/getUserDetailsFromURL.ts
+++ b/Chat/src/app/utils/getUserDetailsFromURL.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export type UserDetails = {
+  userId: string;
+  token: string;
+  displayName: string;
+};
+
+/**
+ *
+ * The user details of an existing participant are extracted from the url
+ * using URLsearchparams.
+ *
+ * @returns The current userId, accessToken and display name as an object
+ *
+ */
+export const getUserDetailsFromURL = (): UserDetails | null => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const userId = urlParams.get('userId');
+  const token = urlParams.get('token');
+  const displayName = urlParams.get('displayName') ?? '';
+
+  if (!userId || !token) {
+    return null;
+  }
+
+  return {
+    userId,
+    token,
+    displayName
+  };
+};

--- a/Server/src/app.ts
+++ b/Server/src/app.ts
@@ -14,6 +14,7 @@ import getEndpointUrl from './routes/getEndpointUrl';
 import isValidThread from './routes/isValidThread';
 import userConfig from './routes/userConfig';
 import createThread from './routes/createThread';
+import addThread from './routes/addThread';
 import addUser from './routes/addUser';
 
 const app = express();
@@ -29,6 +30,12 @@ app.use(express.static(path.resolve(__dirname, 'build')));
  * purpose: Chat: create a new chat thread
  */
 app.use('/createThread', cors(), createThread);
+
+/**
+ * route: /addThread
+ * purpose: Chat: add existing thread and moderator
+ */
+ app.use('/addThread', cors(), addThread);
 
 /**
  * route: /addUser

--- a/Server/src/lib/chat/moderator.ts
+++ b/Server/src/lib/chat/moderator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AzureCommunicationTokenCredential } from '@azure/communication-common';
+import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
 import { ChatClient, CreateChatThreadOptions, CreateChatThreadRequest } from '@azure/communication-chat';
 import { getEndpoint } from '../envHelper';
 import { threadIdToModeratorCredentialMap } from './threadIdToModeratorTokenMap';
@@ -38,3 +38,19 @@ export const createThread = async (topicName?: string): Promise<string> => {
   threadIdToModeratorCredentialMap.set(threadID, credential);
   return threadID;
 };
+
+export const addThread = async (threadID: string, userId: string) => {
+  const user = {
+    communicationUserId: userId
+  } as CommunicationUserIdentifier;
+
+
+  const credential = new AzureCommunicationTokenCredential({
+    tokenRefresher: async () => (await getToken(user, ['chat', 'voip'])).token,
+    refreshProactively: true
+  });
+
+  threadIdToModeratorCredentialMap.set(threadID, credential);
+  
+  return threadID;
+}

--- a/Server/src/routes/addThread.ts
+++ b/Server/src/routes/addThread.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as express from 'express';
+import { addThread } from '../lib/chat/moderator';
+
+const router = express.Router();
+
+/**
+ * route: /addThread/
+ *
+ * purpose: Add existing chat thread and moderator.
+ *
+ * @param threadId: id of the thread to be added
+ * @param userId: id of the user to be set as the moderator
+ * 
+ * @returns The existing threadId as string
+ *
+ */
+
+router.post('/', async function (req, res, next) {  
+  res.send(await addThread(req.body.threadId, req.body.userId));  
+});
+
+export default router;


### PR DESCRIPTION
## Purpose

Given I've created a thread with participants outside of the Chat Sample, I want to be able to send each participant a URL to the Chat Sample that allows them to join the pre-existing thread as a specific participant.

In its current form the sample has the following limitations:

1. Only threads created in the app can be viewed
2. Only participants created in the app can join the thread 

This PR overcomes these limitations as follows:

1. Adds an `/addThread` endpoint to the server that allows an existing thread ID and associated moderator ID to be added to the `threadIdToModeratorCredentialMap`.
2. Updates the `ConfigurationScreen` component to retrieve a user ID, access token and display name from the URL, which are then used for the current session.

## Pull Request Type

<!-- What kind of change does this Pull Request introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Upstream sample reference

<!-- In most cases, a change here synchronizes this sample with the upstream sample. -->

N/A

## How to Test

*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code

<!-- Add steps to run the tests suite and/or manually test. -->

1. Create an ACS Identity (to be used as the moderator)
2. Create an ACS Chat Thread, with the identity from step 1 as a participant
3. Send the Chat Sample the following request:
    * Path: /addThread
    * Method: POST
    * Body: `{ "userId": "Step 1 User ID", "threadId": "Step 2 Thread ID" }`
4. Ensure the following URL allows the Step 1 Identity to join the thread: `{Chat Sample URL}/?threadId={Step 2 Thread ID}&userId={Step 1 user ID}&token={Step 1 Access Token}&displayName={Step 2 Participant Display Name}`
5. Create an ACS Identity 
6. Add the Identity to the thread as a participant
7. Ensure the following URL allows the Step 5 Identity to join the thread: `{Chat Sample URL}/?threadId={Step 2 Thread ID}&userId={Step 5 user ID}&token={Step 5 Access Token}&displayName={Step 2 Participant Display Name}`

## What to Check

Verify that the following are valid

* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
