### PR TITLE
Adding unit test

### DIFF
--- a/Server/src/azureDeployExistingResource.test.ts
+++ b/Server/src/azureDeployExistingResource.test.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import AzureDeployExistingResource from '../../deploy/azuredeployexistingresource.json';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getExistingResourceArmTemplate = (): any => AzureDeployExistingResource;
+
+describe('AzureDeployExistingResource tests', () => {
+  test('Arm template contains communicationServicesResourceId field', () => {
+    const armTemplate = getExistingResourceArmTemplate();
+    expect(armTemplate.variables).toHaveProperty('communicationServicesResourceId');
+    expect(armTemplate.variables.communicationServicesResourceId).toBe(
+      '<Enter your Azure Communication Services Resource Id>'
+    );
+  });
+});

--- a/Server/tsconfig.json
+++ b/Server/tsconfig.json
@@ -15,6 +15,7 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
+    "resolveJsonModule": true,
   },
   "include": ["src", "bin"],
   "exclude": [


### PR DESCRIPTION
## Purpose

On Sample Applications Blade for a Communication Service Resource, the Web Chat Hero Sample currently points to an ARM Template in a specific branch and specific commit.

This will be changed to point to the latest main for the sample. This unit test is being added as a check to make sure that the azuredeployexistingresource.json file has the required property - "communicationServicesResourceId"

In addition, a change in the tsconfig file is also needed which enables the file to be imported as a module - https://stackoverflow.com/questions/49996456/importing-json-file-in-typescript

## Pull Request Type

<!-- What kind of change does this Pull Request introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## Upstream sample reference

<!-- In most cases, a change here synchronizes this sample with the upstream sample. -->

Links to PR(s) that made the original change in the [upstream sample]

* https://github.com/Azure-Samples/communication-services-web-chat-hero/pull/51

## How to Test

*  Get the code

Forked from original sample-

* Test the code
cd web-calling-hero\Server
npm run test

<!-- Add steps to run the tests suite and/or manually test. -->

```
```

## What to Check

Verify that the following are valid
![image](https://user-images.githubusercontent.com/100614160/198107562-9d8203e1-0cd1-4f94-96bf-2a78b4acf23e.png)


* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
